### PR TITLE
ci(github): fix pnpm/action-setup version to v2.4.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
           echo "PNPM_VERSION=${pnpm}" >> $GITHUB_ENV
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v2.4.0
         with:
           version: ${{ env.PNPM_VERSION }}
           run_install: false


### PR DESCRIPTION
Fix pnpm/action-setup version to v2.4.0 because renovate bot can not detect "v2" like version.

---

*This change was executed automatically with [Shepherd](https://github.com/NerdWalletOSS/shepherd).* 💚🤖